### PR TITLE
feat: warning on isPrimaryKey and isFilterable mismatch

### DIFF
--- a/src/fields/lib/abstract-field.js
+++ b/src/fields/lib/abstract-field.js
@@ -75,6 +75,9 @@ module.exports = class AbstractField {
     if (this.isWritableOnce) this.isRequired = true;
     if (this.isRequired) this.isWritable = true;
     if (this.isPrimaryKey && !options.hasOwnProperty('isFilterable')) this.isFilterable = true;
+    if (this.isPrimaryKey && !this.isFilterable) {
+      Restypie.Logger.warn(`isPrimaryKey implies isFilterable for key ${this.key}`);
+    }
     if (this.isFilterable) this.isReadable = true;
     this.isUpdatable = this.isWritableOnce ? false : this.isWritable;
 


### PR DESCRIPTION
Setting `isPrimaryKey` implicitly means setting `isFilterable` to be `true`. Made it a warning if it's set to false. 