### PR TITLE
Add changes for default select value not in schema exception detection

### DIFF
--- a/src/resources/lib/abstract-resource.js
+++ b/src/resources/lib/abstract-resource.js
@@ -244,6 +244,15 @@ module.exports = class AbstractResource extends Restypie.Resources.AbstractCoreR
     if (!Utils.isValidNumber(this.defaultLimit)) throw new TypeError('Property `defaultLimit` should be a number');
     if (!Utils.isValidNumber(this.maxLimit)) throw new TypeError('Property `maxLimit` should be a number');
     
+    const schema = this.schema;
+
+    if (this.defaultSelect) {
+      const defaultSelect = this.defaultSelect;
+      for (const select in defaultSelect) {
+        if (!schema.hasOwnProperty(defaultSelect[select]))
+          throw new Error('Schema doesnt have this property ' + this.defaultSelect[select]);
+      }
+    }
   }
 
 

--- a/test/resource-test-suite/basic-routes/get-single.js
+++ b/test/resource-test-suite/basic-routes/get-single.js
@@ -39,6 +39,14 @@ module.exports = function (Fixtures) {
       });
     });
 
+    it('should populate resouce', function () {
+      return Fixtures.generateMyResource().then((resource) => {
+        return Fixtures.getMyResource(resource.id);
+      }).then((resource) => {
+        resource.should.have.keys(['id', 'name']);
+      });
+    });
+
     it('should populate users on jobs resource', function () {
       const usersCount = 2;
 

--- a/test/resource-test-suite/index.js
+++ b/test/resource-test-suite/index.js
@@ -41,6 +41,7 @@ module.exports = function (options) {
   const SlackTeamsResource = require('./resources/slack-teams')(options);
   const UserSlackTeamsResource = require('./resources/user-slack-teams')(options);
   const SlackTeamChannelsResource = require('./resources/slack-team-channels')(options);
+  const MyResource = require('./resources/my-resources')(options);
 
   switch (options.routerType) {
 
@@ -68,7 +69,8 @@ module.exports = function (options) {
       users: UsersResource,
       slackTeams: SlackTeamsResource,
       userSlackTeams: UserSlackTeamsResource,
-      slackTeamChannels: SlackTeamChannelsResource
+      slackTeamChannels: SlackTeamChannelsResource,
+      myResources: MyResource
     })
     .launch(router, { port: SERVER_PORT });
 

--- a/test/resource-test-suite/resources/my-resources.js
+++ b/test/resource-test-suite/resources/my-resources.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Restypie = require('../../../');
+
+module.exports = function (options) {
+
+  const api = options.api;
+  
+  return class MyResource extends Restypie.Resources.FixturesResource {
+    get path() { return '/my-resources'; }
+    //get defaultSelect() { return ['id2', 'names'] }
+    get routes() {
+      return [
+        Restypie.BasicRoutes.PostRoute,
+        Restypie.BasicRoutes.GetSingleRoute,
+        Restypie.BasicRoutes.GetManyRoute,
+        Restypie.BasicRoutes.PatchSingleRoute,
+        Restypie.BasicRoutes.DeleteSingleRoute
+      ];
+    }
+    get schema() {
+      return {
+        id: { type: 'int', isPrimaryKey: true },
+        name: { type: String, isWritable: true, isFilterable: true, filteringWeight: 100 }
+      };
+    }
+  }
+  
+};

--- a/test/resource-test-suite/utils/fixtures.js
+++ b/test/resource-test-suite/utils/fixtures.js
@@ -454,6 +454,24 @@ module.exports = function (supertest, app, api) {
     static generateSlackTeamChannels(count, generator) {
       return Fixtures.generateResources(count, generator, Fixtures.generateSlackTeamChannel);
     }
+
+    /*******************************************************************************************************************
+     * MyResource
+     */
+    static createMyResource(data, options) {
+      return Fixtures.createResource('/v1/my-resources', data, options);
+    }
+
+    static generateMyResource(generator) {
+      const data = Object.assign({
+        name: `Resource-${Fixtures.uuid()}`
+      }, Fixtures.parameterToGenerator(generator)());
+
+      return Fixtures.createMyResource(data, { rejectOnError: true });
+    }
+    static getMyResource(id, options) {
+      return Fixtures.getResource('/v1/my-resources', id, options);
+    }
     
   };
 


### PR DESCRIPTION
If I add this line in the new resource,  get defaultSelect() { return ['id2', 'names'] }
no test runs, we can look into it together.