### PR TITLE
🐛  Change parser.on.finish to parser.on.end to properly catch errors.

### DIFF
--- a/src/resources/lib/abstract-resource.js
+++ b/src/resources/lib/abstract-resource.js
@@ -1356,7 +1356,7 @@ module.exports = class AbstractResource extends Restypie.Resources.AbstractCoreR
 
       parser.on('error', onError);
 
-      parser.on('finish', function () {
+      parser.on('end', function () {
         body = formDataToObject.toObj(body);
         Object.assign(body, files);
         bundle.setBody(body);


### PR DESCRIPTION
Awaiting tests and probably need to add a failing test validating this change fixes it.